### PR TITLE
Not gate reduction

### DIFF
--- a/builder/circuit_builder.c
+++ b/builder/circuit_builder.c
@@ -54,6 +54,7 @@ gate_AND(garble_circuit *gc, garble_context *ctxt, int input0, int input1,
 {
     _gate(gc, ctxt, input0, input1, output, GARBLE_GATE_AND);
 }
+
 void
 gate_XOR(garble_circuit *gc, garble_context *ctxt, int input0, int input1,
          int output)

--- a/builder/circuit_builder.c
+++ b/builder/circuit_builder.c
@@ -54,7 +54,6 @@ gate_AND(garble_circuit *gc, garble_context *ctxt, int input0, int input1,
 {
     _gate(gc, ctxt, input0, input1, output, GARBLE_GATE_AND);
 }
-
 void
 gate_XOR(garble_circuit *gc, garble_context *ctxt, int input0, int input1,
          int output)
@@ -72,7 +71,7 @@ gate_OR(garble_circuit *gc, garble_context *ctxt, int input0, int input1,
 void
 gate_NOT(garble_circuit *gc, garble_context *ctxt, int input0, int output)
 {
-    _gate(gc, ctxt, input0, input0, output, GARBLE_GATE_NOT);
+    _gate(gc, ctxt, input0, wire_zero(gc), output, GARBLE_GATE_XOR);
 }
 
 int


### PR DESCRIPTION
Made NOT gates use an XOR gate with a fixed zero wire, to increase efficiency.
